### PR TITLE
Add macOS instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
+UNAME := $(shell uname)
 CFLAGS = -Wall -g -Werror
 LDLIBS = -lopenal -lalut -lSDL -lSDL_image -lSDL_ttf
+
+ifeq ($(UNAME), Darwin)
+CFLAGS = -Wall -g
+# install deps via 'brew install alut sdl_image sdl_ttf`
+LDLIBS = -L/usr/local/lib -lSDLmain -lSDL -Wl,-framework,Cocoa -lSDL_image -lSDL_ttf -L/usr/local/Cellar/freealut/1.1.0/lib -lalut -framework OpenAL
+endif
 
 all: letters
 


### PR DESCRIPTION
This PR improves the Makefile to include the correct linker flags so it
compiles on macOS. Because OpenAL is deprecated on macOS, there are
deprecation warnings during the compilation step, hence I removed
`-Werror` for the macOS build.
